### PR TITLE
Allow user to define a truncation symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ GitHub action that will truncate a passed string if it is greater than the passe
 | `stringToTruncte`                | The string to truncate                                                                     |
 | `maxLength`                      | The max length of the returned string                                                      |
 | `removeDanglingCharacters`       | Remove any of the provided dangling characters. No seperation between characters e.g. -,!% |
+| `truncationSymbol`               | Appends a string to the end of the truncated string to indicate truncation has occurred    |
 
 ## Outputs
 
@@ -82,3 +83,25 @@ on: [ push ]
 ```
 
 Will return `abcdefg`
+
+```yaml
+Name: Truncate String and apply truncation symbol
+
+on: [ push ]
+
+  jobs:
+    truncate:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Truncate String
+          uses: 2428392/gh-truncate-string-action@v1.2.0
+          id: truncatedString
+          with:
+            stringToTruncate: 'abcde'
+            maxLength: 4
+            truncationSymbol: '...'
+        - name: Echo string
+          run: echo ${{ steps.truncatedString.outputs.string }}
+```
+
+Will return `a...`

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ function checkAndRemoveDangling(removableCharacters, str) {
 }
 
 function main() {
-    let text = core.getInput('stringToTruncate', {
+    const stringToTruncate = core.getInput('stringToTruncate', {
         required: true,
     });
     const maxLength = core.getInput('maxLength', { required: true });
@@ -20,23 +20,25 @@ function main() {
     const danglingCharacters = [...danglingCharactersInput];
     const truncationSymbol = core.getInput('truncationSymbol', { required: false });
 
-    if (text.length > maxLength) {
+    let acceptableString = stringToTruncate;
+    if (stringToTruncate.length > maxLength) {
         if (truncationSymbol) {
             if (truncationSymbol.length > maxLength) {
-                text = truncationSymbol.substring(0, maxLength);
+                acceptableString = truncationSymbol.substring(0, maxLength);
             } else {
-                text = text.substring(0, maxLength - truncationSymbol.length) + truncationSymbol;
+                acceptableString =
+                    stringToTruncate.substring(0, maxLength - truncationSymbol.length) + truncationSymbol;
             }
         } else {
-            text = text.substring(0, maxLength);
+            acceptableString = stringToTruncate.substring(0, maxLength);
         }
     }
 
     if (danglingCharacters.length && !truncationSymbol) {
-        text = checkAndRemoveDangling(danglingCharacters, text);
+        acceptableString = checkAndRemoveDangling(danglingCharacters, acceptableString);
     }
 
-    core.setOutput('string', text);
+    core.setOutput('string', acceptableString);
 }
 
 main();

--- a/src/main.js
+++ b/src/main.js
@@ -12,23 +12,31 @@ function checkAndRemoveDangling(removableCharacters, str) {
 }
 
 function main() {
-    const stringToTruncate = core.getInput('stringToTruncate', {
+    let text = core.getInput('stringToTruncate', {
         required: true,
     });
     const maxLength = core.getInput('maxLength', { required: true });
     const danglingCharactersInput = core.getInput('removeDanglingCharacters', { required: false });
     const danglingCharacters = [...danglingCharactersInput];
+    const truncationSymbol = core.getInput('truncationSymbol', { required: false });
 
-    let acceptableString = stringToTruncate;
-    if (stringToTruncate.length > maxLength) {
-        acceptableString = stringToTruncate.substring(0, maxLength);
+    if (text.length > maxLength) {
+        if (truncationSymbol) {
+            if (truncationSymbol.length > maxLength) {
+                text = truncationSymbol.substring(0, maxLength);
+            } else {
+                text = text.substring(0, maxLength - truncationSymbol.length) + truncationSymbol;
+            }
+        } else {
+            text = text.substring(0, maxLength);
+        }
     }
 
     if (danglingCharacters.length) {
-        acceptableString = checkAndRemoveDangling(danglingCharacters, acceptableString);
+        text = checkAndRemoveDangling(danglingCharacters, text);
     }
 
-    core.setOutput('string', acceptableString);
+    core.setOutput('string', text);
 }
 
 main();

--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,7 @@ function main() {
         }
     }
 
-    if (danglingCharacters.length) {
+    if (danglingCharacters.length && !truncationSymbol) {
         text = checkAndRemoveDangling(danglingCharacters, text);
     }
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -63,7 +63,7 @@ test.serial('returns non truncated string when string length is equal to max len
     await assertOutput(t.context.str, t);
 });
 
-test.serial('returns truncated string without dangaling hyphen', async (t) => {
+test.serial('returns truncated string without dangling hyphen', async (t) => {
     process.env.INPUT_STRINGTOTRUNCATE = t.context.strWithHyphenLessThanMax;
     process.env.INPUT_MAXLENGTH = 10;
     process.env.INPUT_REMOVEDANGLINGCHARACTERS = '-';
@@ -71,7 +71,7 @@ test.serial('returns truncated string without dangaling hyphen', async (t) => {
     await assertOutput('abcdefghi', t);
 });
 
-test.serial('returns truncated string when length = max length but has dangaling hyphen', async (t) => {
+test.serial('returns truncated string when length = max length but has dangling hyphen', async (t) => {
     process.env.INPUT_STRINGTOTRUNCATE = t.context.strWithHyphenAtMax;
     process.env.INPUT_MAXLENGTH = 27;
     process.env.INPUT_REMOVEDANGLINGCHARACTERS = '-';

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -142,13 +142,10 @@ test.serial(
     },
 );
 
-test.serial(
-    'returns empty string when max length is 0',
-    async (t) => {
-        process.env.INPUT_STRINGTOTRUNCATE = 'abcde';
-        process.env.INPUT_MAXLENGTH = 0;
-        process.env.INPUT_TRUNCATIONSYMBOL = '...';
-        require('../src/main');
-        await assertOutput('', t);
-    },
-);
+test.serial('returns empty string when max length is 0', async (t) => {
+    process.env.INPUT_STRINGTOTRUNCATE = 'abcde';
+    process.env.INPUT_MAXLENGTH = 0;
+    process.env.INPUT_TRUNCATIONSYMBOL = '...';
+    require('../src/main');
+    await assertOutput('', t);
+});

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -97,3 +97,58 @@ test.serial(
         await assertOutput('abcd', t);
     },
 );
+
+test.serial(
+    'returns truncated string with full truncation symbol appended when max length is greater than the length of the truncation symbol',
+    async (t) => {
+        process.env.INPUT_STRINGTOTRUNCATE = 'abcde';
+        process.env.INPUT_MAXLENGTH = 4;
+        process.env.INPUT_TRUNCATIONSYMBOL = '...';
+        require('../src/main');
+        await assertOutput('a...', t);
+    },
+);
+
+test.serial(
+    'returns truncation symbol only when max length is equal to the length of the truncation symbol',
+    async (t) => {
+        process.env.INPUT_STRINGTOTRUNCATE = 'abcde';
+        process.env.INPUT_MAXLENGTH = 3;
+        process.env.INPUT_TRUNCATIONSYMBOL = '...';
+        require('../src/main');
+        await assertOutput('...', t);
+    },
+);
+
+test.serial(
+    'returns partial truncation symbol when the max length is shorter than the length of the truncation symbol 1',
+    async (t) => {
+        process.env.INPUT_STRINGTOTRUNCATE = 'abcde';
+        process.env.INPUT_MAXLENGTH = 2;
+        process.env.INPUT_TRUNCATIONSYMBOL = '...';
+        require('../src/main');
+        await assertOutput('..', t);
+    },
+);
+
+test.serial(
+    'returns partial truncation symbol when the max length is shorter than the length of the truncation symbol 2',
+    async (t) => {
+        process.env.INPUT_STRINGTOTRUNCATE = 'abcde';
+        process.env.INPUT_MAXLENGTH = 1;
+        process.env.INPUT_TRUNCATIONSYMBOL = '...';
+        require('../src/main');
+        await assertOutput('.', t);
+    },
+);
+
+test.serial(
+    'returns empty string when max length is 0',
+    async (t) => {
+        process.env.INPUT_STRINGTOTRUNCATE = 'abcde';
+        process.env.INPUT_MAXLENGTH = 0;
+        process.env.INPUT_TRUNCATIONSYMBOL = '...';
+        require('../src/main');
+        await assertOutput('', t);
+    },
+);

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -149,3 +149,15 @@ test.serial('returns empty string when max length is 0', async (t) => {
     require('../src/main');
     await assertOutput('', t);
 });
+
+test.serial(
+    'returns truncated string and ignores removal of dangling characters when setting the truncation symbol setting',
+    async (t) => {
+        process.env.INPUT_STRINGTOTRUNCATE = 'abcde';
+        process.env.INPUT_MAXLENGTH = 4;
+        process.env.INPUT_REMOVEDANGLINGCHARACTERS = '.';
+        process.env.INPUT_TRUNCATIONSYMBOL = '...';
+        require('../src/main');
+        await assertOutput('a...', t);
+    },
+);

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -37,6 +37,7 @@ test.afterEach(() => {
     delete process.env.INPUT_STRINGTOTRUNCATE;
     delete process.env.INPUT_MAXLENGTH;
     delete process.env.INPUT_REMOVEDANGLINGCHARACTERS;
+    delete process.env.INPUT_TRUNCATIONSYMBOL;
     delete process.env.GITHUB_OUTPUT;
     delete require.cache[require.resolve('../src/main')];
 });


### PR DESCRIPTION
This allows the user to define a `truncationSymbol`, so that they can append some text to the end of their truncated string:

`this would be an example of the truncated symbol on text that is being trunca...`, where `truncationSymbol = ...`

In some cases, being able to include this might help the user understand the truncation is intentional.  I'm using this action in a workflow that publishes to Discord and I think it would help the users know that the truncation is done on purpose and not just an accidental thing.

One change that might be controversial is consildating the two separate strings (`stringToTruncate` and `acceptableString`) into one (simply `text). so that its easier to follow around in the newly added logic. I can revert this if you'd rather use a few strings to track the different versions.